### PR TITLE
SudachiTokenizer should set `doc.is_tagger`

### DIFF
--- a/ginza/sudachi_tokenizer.py
+++ b/ginza/sudachi_tokenizer.py
@@ -121,6 +121,7 @@ class SudachiTokenizer(DummyTokenizer):
             token._.sudachi = morph
         if self.use_sentence_separator:
             separate_sentences(doc)
+        doc.is_tagged = True
         return doc
 
     # add dummy methods for to_bytes, from_bytes, to_disk and from_disk to


### PR DESCRIPTION
Hi, thank you for this great repo!

I found that `doc.is_tagged` isn't set by `ja_ginza`.
This property should be set by `SudachiTokenizer` like `spacy.Tagger` (https://github.com/explosion/spaCy/blob/45efdb1ef7ca9323d058a3312747b7b258154ead/spacy/pipeline/pipes.pyx#L454)