### PR TITLE
Fix NE label

### DIFF
--- a/ginza_util/conllu_to_json.py
+++ b/ginza_util/conllu_to_json.py
@@ -337,7 +337,7 @@ def convert_lines(path, lines, tokenizer, paragraph_id_regex, n_sents, extend_de
                 elif label.startswith('I-'):
                     if not ent_label or ent_label != label[2:]:
                         raise Exception('Bad NE label: ' + line)
-                elif label.startswith('E-'):
+                elif label.startswith('L-'):
                     if not ent_label or ent_label != label[2:]:
                         raise Exception('Bad NE label: ' + line)
                     ents.append({


### PR DESCRIPTION
Not entirely sure this is correct, but trying to run the Ginza conllu conversion script failed when it found an L- tag. It looks like the tag parser was looking for an E- tag, and changing that to L- allowed conversion to run without issue.

I guess this was an oversight in moving between tag schemes, but let me know if something else is going on.