### PR TITLE
ginza/ginzame command の split mode の default を "C" に変更する

### DIFF
--- a/docs/command_line_tool.md
+++ b/docs/command_line_tool.md
@@ -23,8 +23,8 @@ $ ginza
 
 `ginzame`コマンドでオープンソース形態素解析エンジン [MeCab](https://taku910.github.io/mecab/) の`mecab`コマンドに近い形式で解析結果を出力することができます。
 `ginzame`コマンドは形態素解析処理のみをマルチプロセスで高速に実行します。
-このコマンドと`mecab`の出力形式の相違点として、 
-最終フィールド（発音）が常に`*`となることに注意して下さい。
+このコマンドと`mecab`の出力形式の相違点として、最終フィールド（発音）が常に`*`となること、
+ginza の split_mode はデフォルトが `C` なので unidic 相当の単語分割を得るためには `-s A` を指定する必要があることに注意して下さい。
 ```console
 $ ginzame
 銀座でランチをご一緒しましょう。
@@ -55,7 +55,8 @@ EOS
     使用するモデルに応じて、事前に `pip install ja-ginza-electra` のようにパッケージをダウンロードする必要があります。
     `--model-path`, `--ensure-model` のどちらも指定されない場合には `ja_ginza_electra`、`ja_ginza` の順の優先度でロード可能なモデルを利用します。
 - `--split-mode <string>`, `-s <string>`
-     複合名詞の分割モードを指定します。モードは [sudachi](https://github.com/WorksApplications/Sudachi#the-modes-of-splitting) に準拠し、`A`、`B`、`C`のいずれかを指定できます。`A`が分割が最も短く複合名詞が UniDic 短単位まで分割され、 `C` では固有名詞が抽出されます。`B` は二つの中間の単位に分割されます。
+     複合名詞の分割モードを指定します。モードは [sudachi](https://github.com/WorksApplications/Sudachi#the-modes-of-splitting) に準拠し、`A`、`B`、`C`のいずれかを指定できます。デフォルト値は `C` です。
+     `A`が分割が最も短く複合名詞が UniDic 短単位まで分割され、 `C` では固有名詞が抽出されます。`B` は二つの中間の単位に分割されます。
 - `--hash-comment <string>`, `-c <string>`
     行頭が `#` から始まる行を解析対象とするかのモードを指定します。次の値のいずれかを指定できます。
         - `print`
@@ -121,7 +122,7 @@ $ ginza -f json
 
 日本語係り受け解析器 [CaboCha](https://taku910.github.io/cabocha/) の`cabocha -f1`のラティス形式に近い解析結果を出力する場合は
 `ginza -f 1` または `ginza -f cabocha` を実行して下さい。
-このオプションと`cabocha -f1`の出力形式の相違点として、 
+このオプションと`cabocha -f1`の出力形式の相違点として、
 スラッシュ記号`/`に続く`func_index`フィールドが常に自立語の終了位置（機能語があればその開始位置に一致）を示すこと、
 機能語認定基準が一部異なること、
 に注意して下さい。

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -49,7 +49,7 @@ class _OutputWrapper:
 def run(
     model_path: Optional[str] = None,
     ensure_model: Optional[str] = None,
-    split_mode: Optional[str] = None,
+    split_mode: Optional[str] = "C",
     hash_comment: str = "print",
     output_path: Optional[Path] = None,
     output_format: str = "0",
@@ -185,7 +185,7 @@ def _analyze_parallel(analyzer: Analyzer, output: _OutputWrapper, files: Iterabl
 
 @plac.annotations(
     model_path=("model directory path", "option", "b", str),
-    split_mode=("split mode", "option", "s", str, ["A", "B", "C", None]),
+    split_mode=("split mode", "option", "s", str, ["A", "B", "C"]),
     hash_comment=("hash comment", "option", "c", str, ["print", "skip", "analyze"]),
     output_path=("output path", "option", "o", Path),
     use_normalized_form=("overriding Token.lemma_ by normalized_form of SudachiPy", "flag", "n"),
@@ -194,7 +194,7 @@ def _analyze_parallel(analyzer: Analyzer, output: _OutputWrapper, files: Iterabl
 )
 def run_ginzame(
     model_path=None,
-    split_mode=None,
+    split_mode="C",
     hash_comment="print",
     output_path=None,
     use_normalized_form=False,
@@ -223,7 +223,7 @@ def main_ginzame():
 @plac.annotations(
     model_path=("model directory path", "option", "b", str),
     ensure_model=("select model either ja_ginza or ja_ginza_electra", "option", "m", str, ["ja_ginza", "ja-ginza", "ja_ginza_electra", "ja-ginza-electra", None]),
-    split_mode=("split mode", "option", "s", str, ["A", "B", "C", None]),
+    split_mode=("split mode", "option", "s", str, ["A", "B", "C"]),
     hash_comment=("hash comment", "option", "c", str, ["print", "skip", "analyze"]),
     output_path=("output path", "option", "o", Path),
     output_format=("output format", "option", "f", str, ["0", "conllu", "1", "cabocha", "2", "mecab", "3", "json"]),
@@ -236,7 +236,7 @@ def main_ginzame():
 def run_ginza(
     model_path=None,
     ensure_model=None,
-    split_mode=None,
+    split_mode="C",
     hash_comment="print",
     output_path=None,
     output_format="conllu",


### PR DESCRIPTION
split mode のデフォルト値での挙動が ginza/ginzame で異なっていたため, デフォルトの挙動を "C" に統一しました.