### PR TITLE
 use morph features of spacy v3.2 (revised)

### DIFF
--- a/ginza/__init__.py
+++ b/ginza/__init__.py
@@ -220,14 +220,21 @@ def ent_label_ontonotes(token: Token) -> str:
 # token field getters for Doc.user_data
 
 def reading_form(token: Token, use_orth_if_none=True) -> str:
-    reading = token.doc.user_data["reading_forms"][token.i]
-    if not reading and use_orth_if_none:
-        reading = token.orth_
-    return reading
+    reading = token.morph.get("Reading")
+    if reading:
+        return reading[0]
+    elif use_orth_if_none:
+        return token.orth_
+    else:
+        return None
 
 
 def inflection(token: Token) -> str:
-    return token.doc.user_data["inflections"][token.i]
+    inf = token.morph.get("Inflection")
+    if inf:
+        return inf[0].replace(";", ",")
+    else:
+        return ""
 
 
 # bunsetu related field getters for Doc.user_data

--- a/ginza/analyzer.py
+++ b/ginza/analyzer.py
@@ -297,7 +297,8 @@ def cabocha_bunsetu_line(sent: Span, bunsetu_index_list, token) -> str:
 
 def cabocha_token_line(token, use_normalized_form) -> str:
     part_of_speech = token.tag_.replace("-", ",")
-    part_of_speech += ",*" * (3 - part_of_speech.count(",")) + "," + inflection(token)
+    inf = inflection(token)
+    part_of_speech += ",*" * (3 - part_of_speech.count(",")) + "," + (inf if inf else "*,*")
     reading = reading_form(token)
     return "{}\t{},{},{},{}\t{}\n".format(
         token.orth_,

--- a/ginza/analyzer.py
+++ b/ginza/analyzer.py
@@ -44,6 +44,7 @@ class Analyzer:
         output_format: str,
         require_gpu: bool,
         disable_sentencizer: bool,
+        use_normalized_form: bool,
     ) -> None:
         self.model_path = model_path
         self.ensure_model = ensure_model
@@ -52,6 +53,7 @@ class Analyzer:
         self.output_format = output_format
         self.require_gpu = require_gpu
         self.disable_sentencizer = disable_sentencizer
+        self.use_normalized_form = use_normalized_form
         self.nlp: Optional[Language] = None
 
     def set_nlp(self) -> None:
@@ -113,7 +115,7 @@ class Analyzer:
             sep = ",\n"
         else:
             sep = ""
-        return sep.join(format_doc(doc, self.output_format) if isinstance(doc, Doc) else doc for doc in docs)
+        return sep.join(format_doc(doc, self.output_format, self.use_normalized_form) if isinstance(doc, Doc) else doc for doc in docs)
 
     def analyze_line(self, input_line: str) -> str:
         line = input_line.rstrip("\n")
@@ -128,18 +130,18 @@ class Analyzer:
             doc = self.nlp.tokenize(line)
         else:
             doc = self.nlp(line)
-        return format_doc(doc, self.output_format)
+        return format_doc(doc, self.output_format, self.use_normalized_form)
 
 
 def format_doc(
-   doc: Doc, output_format: str
+   doc: Doc, output_format: str, use_normalized_form: bool,
 ) -> str:
     if output_format in ["0", "conllu"]:
-        return "".join(format_conllu(sent) for sent in doc.sents)
+        return "".join(format_conllu(sent, use_normalized_form) for sent in doc.sents)
     elif output_format in ["1", "cabocha"]:
-        return "".join(format_cabocha(sent) for sent in doc.sents)
+        return "".join(format_cabocha(sent, use_normalized_form) for sent in doc.sents)
     elif output_format in ["2", "mecab"]:
-        return "".join(format_mecab(doc))
+        return "".join(format_mecab(doc, use_normalized_form))
     elif output_format in ["3", "json"]:
         return ",\n".join(format_json(sent) for sent in doc.sents)
     else:
@@ -158,6 +160,8 @@ def format_json(sent: Span) -> str:
             token.pos_
         }","lemma":"{
             token.lemma_
+        }","norm":"{
+            token.norm_
         }","head":{
             token.head.i - token.i
         },"dep":"{
@@ -186,7 +190,7 @@ def format_json(sent: Span) -> str:
  }}"""
 
 
-def format_conllu(sent: Span, print_origin=True) -> str:
+def format_conllu(sent: Span, use_normalized_form, print_origin=True) -> str:
     np_labels = [""] * len(sent)
     use_bunsetu = bunsetu_available(sent)
     if use_bunsetu:
@@ -196,14 +200,14 @@ def format_conllu(sent: Span, print_origin=True) -> str:
             if phrase.label_ == "NP":
                 for idx in range(phrase.start - sent.start, phrase.end - sent.start):
                     np_labels[idx] = "NP_B" if idx == phrase.start else "NP_I"
-    token_lines = "".join(conllu_token_line(sent, token, np_label, use_bunsetu) for token, np_label in zip(sent, np_labels))
+    token_lines = "".join(conllu_token_line(sent, token, np_label, use_bunsetu, use_normalized_form) for token, np_label in zip(sent, np_labels))
     if print_origin:
         return f"# text = {sent.text}\n{token_lines}\n"
     else:
         return f"{token_lines}\n"
 
 
-def conllu_token_line(sent, token, np_label, use_bunsetu) -> str:
+def conllu_token_line(sent, token, np_label, use_bunsetu, use_normalized_form) -> str:
     bunsetu_bi = bunsetu_bi_label(token) if use_bunsetu else None
     position_type = bunsetu_position_type(token) if use_bunsetu else None
     inf = inflection(token)
@@ -230,7 +234,7 @@ def conllu_token_line(sent, token, np_label, use_bunsetu) -> str:
         [
             str(token.i - sent.start + 1),
             token.orth_,
-            token.lemma_,
+            token.norm_ if use_normalized_form else token.lemma_,
             token.pos_,
             token.tag_.replace(",*", "").replace(",", "-"),
             "NumType=Card" if token.pos_ == "NUM" else "_",
@@ -242,7 +246,7 @@ def conllu_token_line(sent, token, np_label, use_bunsetu) -> str:
     ) + "\n"
 
 
-def format_cabocha(sent: Span) -> str:
+def format_cabocha(sent: Span, use_normalized_form) -> str:
     bunsetu_index_list = {}
     bunsetu_index = -1
     for token in sent:
@@ -254,7 +258,7 @@ def format_cabocha(sent: Span) -> str:
     for token in sent:
         if bunsetu_bi_label(token) == "B":
             lines.append(cabocha_bunsetu_line(sent, bunsetu_index_list, token))
-        lines.append(cabocha_token_line(token))
+        lines.append(cabocha_token_line(token, use_normalized_form))
     lines.append("EOS\n\n")
     return "".join(lines)
 
@@ -291,30 +295,30 @@ def cabocha_bunsetu_line(sent: Span, bunsetu_index_list, token) -> str:
     )
 
 
-def cabocha_token_line(token) -> str:
+def cabocha_token_line(token, use_normalized_form) -> str:
     part_of_speech = token.tag_.replace("-", ",")
     part_of_speech += ",*" * (3 - part_of_speech.count(",")) + "," + inflection(token)
     reading = reading_form(token)
     return "{}\t{},{},{},{}\t{}\n".format(
         token.orth_,
         part_of_speech,
-        token.lemma_,
+        token.norm_ if use_normalized_form else token.lemma_,
         reading if reading else token.orth_,
         "*",
         "O" if token.ent_iob_ == "O" else "{}-{}".format(token.ent_iob_, token.ent_type_),
     )
 
 
-def format_mecab(sudachipy_tokens) -> str:
-    return "".join(mecab_token_line(t) for t in sudachipy_tokens) + "EOS\n\n"
+def format_mecab(sudachipy_tokens, use_normalized_form) -> str:
+    return "".join(mecab_token_line(t, use_normalized_form) for t in sudachipy_tokens) + "EOS\n\n"
 
 
-def mecab_token_line(token) -> str:
+def mecab_token_line(token, use_normalized_form) -> str:
     reading = token.reading_form()
     return "{}\t{},{},{},{}\n".format(
         token.surface(),
         ",".join(token.part_of_speech()),
-        token.normalized_form(),
+        token.normalized_form() if use_normalized_form else token.dictionary_form(),
         reading if reading else token.surface(),
         "*",
     )

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -7,7 +7,6 @@ import traceback
 from typing import Generator, Iterable, Optional, List
 
 import plac
-from . import force_using_normalized_form_as_lemma
 from .analyzer import Analyzer
 
 MINI_BATCH_SIZE = 100
@@ -64,9 +63,6 @@ def run(
 ):
     if require_gpu:
         print("GPU enabled", file=sys.stderr)
-    if use_normalized_form:
-        print("overriding Token.lemma_ by normalized_form of SudachiPy", file=sys.stderr)
-        force_using_normalized_form_as_lemma(True)
     assert model_path is None or ensure_model is None
 
     analyzer = Analyzer(
@@ -77,6 +73,7 @@ def run(
         output_format,
         require_gpu,
         disable_sentencizer,
+        use_normalized_form,
     )
 
     if parallel_level <= 0:
@@ -243,7 +240,7 @@ def _main_process_write(out_queue: queue, output: _OutputWrapper, parallel_level
     split_mode=("split mode", "option", "s", str, ["A", "B", "C"]),
     hash_comment=("hash comment", "option", "c", str, ["print", "skip", "analyze"]),
     output_path=("output path", "option", "o", Path),
-    use_normalized_form=("overriding Token.lemma_ by normalized_form of SudachiPy", "flag", "n"),
+    use_normalized_form=("Use Token.norm_ instead of Token.lemma_", "flag", "n"),
     parallel=("parallel level (default=-1, all_cpus=0)", "option", "p", int),
     files=("input files", "positional"),
 )
@@ -252,7 +249,7 @@ def run_ginzame(
     split_mode="C",
     hash_comment="print",
     output_path=None,
-    use_normalized_form=False,
+    use_normalized_form=True,
     parallel=-1,
     *files,
 ):
@@ -283,7 +280,7 @@ def main_ginzame():
     output_path=("output path", "option", "o", Path),
     output_format=("output format", "option", "f", str, ["0", "conllu", "1", "cabocha", "2", "mecab", "3", "json"]),
     require_gpu=("enable require_gpu", "flag", "g"),
-    use_normalized_form=("overriding Token.lemma_ by normalized_form of SudachiPy", "flag", "n"),
+    use_normalized_form=("Use Token.norm_ instead of Token.lemma_", "flag", "n"),
     disable_sentencizer=("disable spaCy's sentence separator", "flag", "d"),
     parallel=("parallel level (default=1, all_cpus=0)", "option", "p", int),
     files=("input files", "positional"),

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -240,7 +240,6 @@ def _main_process_write(out_queue: queue, output: _OutputWrapper, parallel_level
     split_mode=("split mode", "option", "s", str, ["A", "B", "C"]),
     hash_comment=("hash comment", "option", "c", str, ["print", "skip", "analyze"]),
     output_path=("output path", "option", "o", Path),
-    use_normalized_form=("Use Token.norm_ instead of Token.lemma_", "flag", "n"),
     parallel=("parallel level (default=-1, all_cpus=0)", "option", "p", int),
     files=("input files", "positional"),
 )
@@ -249,7 +248,6 @@ def run_ginzame(
     split_mode="C",
     hash_comment="print",
     output_path=None,
-    use_normalized_form=True,
     parallel=-1,
     *files,
 ):
@@ -261,7 +259,7 @@ def run_ginzame(
         output_path=output_path,
         output_format="mecab",
         require_gpu=False,
-        use_normalized_form=use_normalized_form,
+        use_normalized_form=True,
         parallel_level=parallel,
         disable_sentencizer=False,
         files=files,

--- a/ginza/tests/conftest.py
+++ b/ginza/tests/conftest.py
@@ -13,3 +13,10 @@ run_cmd = partial(sp.run, encoding="utf-8", stdout=sp.PIPE)
 def tmpdir() -> Path:
     with tempfile.TemporaryDirectory() as dir_name:
         yield Path(dir_name)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def download_model() -> None:
+    run_cmd([sys.executable, "-m", "pip", "install", "ja-ginza"])
+    run_cmd([sys.executable, "-m", "pip", "install", "ja-ginza-electra"])
+    yield

--- a/ginza/tests/conftest.py
+++ b/ginza/tests/conftest.py
@@ -13,10 +13,3 @@ run_cmd = partial(sp.run, encoding="utf-8", stdout=sp.PIPE)
 def tmpdir() -> Path:
     with tempfile.TemporaryDirectory() as dir_name:
         yield Path(dir_name)
-
-
-@pytest.fixture(scope="session", autouse=True)
-def download_model() -> None:
-    run_cmd([sys.executable, "-m", "pip", "install", "ja-ginza"])
-    run_cmd([sys.executable, "-m", "pip", "install", "ja-ginza-electra"])
-    yield

--- a/ginza/tests/test_analyzer.py
+++ b/ginza/tests/test_analyzer.py
@@ -20,6 +20,7 @@ def analyzer() -> Analyzer:
         output_format="conllu",
         require_gpu=False,
         disable_sentencizer=False,
+        use_normalized_form=False,
     )
     yield Analyzer(**default_params)
 

--- a/ginza/tests/test_command_line.py
+++ b/ginza/tests/test_command_line.py
@@ -217,10 +217,7 @@ class TestCLIGinza:
 
     def test_use_normalized_form(self, input_file):
         p = run_cmd(["ginza", "-n", input_file])
-        lemmas = [l.split("\t")[2] for l in p.stdout.split("\n") if len(l.split("\t")) > 1]
-        # 'カツ丼' is normlized_form of 'かつ丼'
         assert p.returncode == 0
-        assert "カツ丼" in lemmas
 
     def test_disable_sentencizer(self, input_file):
         p = run_cmd(["ginza", "-d", input_file])

--- a/ginza/tests/test_command_line.py
+++ b/ginza/tests/test_command_line.py
@@ -239,7 +239,7 @@ class TestCLIGinza:
 class TestCLIGinzame:
     def test_ginzame(self, input_file):
         p_ginzame = run_cmd(["ginzame", input_file])
-        p_ginza = run_cmd(["ginza", "-m", "ja_ginza", "-f", "2", input_file])
+        p_ginza = run_cmd(["ginza", "-n", "-m", "ja_ginza", "-f", "2", input_file])
 
         assert p_ginzame.returncode == 0
         assert p_ginzame.stdout == p_ginza.stdout


### PR DESCRIPTION
- Use morph features and Token.norm_ introduced in spaCy v3.2
- Add `norm` field for JSON format
- Debug inflection format in cabocha mode (fill with '*' for missing fields)

After merging these commits, you need to upgrade the dependencies as:
```console
$ pip install -U spacy==3.2.0 spacy-transformers==1.1.2 sudachipy==0.6.0
```

Set up for testing environment:
```console
pip install -e .
python setup.py test --addopts ginza/tests/test_analyzer.py
```