### PR TITLE
adjust compound_splitter to spacy v3.2

### DIFF
--- a/ginza/compound_splitter.py
+++ b/ginza/compound_splitter.py
@@ -95,6 +95,13 @@ class CompoundSplitter:
                 else:
                     heads = [(token, last) for _ in range(last)] + [token.head]
                 surfaces = [dtoken.surface for dtoken in sub_tokens]
+                def morph(dtoken):
+                    m = {}
+                    if dtoken.inf:
+                        m["Inflection"] = dtoken.inf
+                    if dtoken.reading:
+                        m["Reading"] = re.sub("[=|]", "_", dtoken.reading)
+                    return "|".join(f"{k}={v}" for k, v in m.items())
                 attrs = {
                     "TAG": [dtoken.tag for dtoken in sub_tokens],
                     "DEP": deps,
@@ -105,7 +112,7 @@ class CompoundSplitter:
                     "LEMMA": [dtoken.lemma for dtoken in sub_tokens],
                     "NORM": [dtoken.norm for dtoken in sub_tokens],
                     "ENT_TYPE": [token_ent_type for dtoken in sub_tokens],
-                    "MORPH": [f'Inflection={dtoken.inf}|Reading={re.sub("[=|]", "_", dtoken.reading)}' for dtoken in sub_tokens],
+                    "MORPH": [morph(dtoken) for dtoken in sub_tokens],
                 }
                 try:
                     with doc.retokenize() as retokenizer:

--- a/ginza/tests/test_command_line.py
+++ b/ginza/tests/test_command_line.py
@@ -246,7 +246,7 @@ class TestCLIGinza:
 class TestCLIGinzame:
     def test_ginzame(self, input_file):
         p_ginzame = run_cmd(["ginzame", input_file])
-        p_ginza = run_cmd(["ginza", "-n", "-m", "ja_ginza", "-f", "2", input_file])
+        p_ginza = run_cmd(["ginza", "-n", "-m", "ja_ginza", "-f", "2", "-s", "A", input_file])
 
         assert p_ginzame.returncode == 0
         assert p_ginzame.stdout == p_ginza.stdout


### PR DESCRIPTION
`compound_splitter` still referring `Doc.user_dict[]`.

From spaCy v3.2
  - `normalized_form` is set to Token.norm
  - `inflections` and `readings` are set in Token.morph
 
Also, current implementation set some Token fields directly after doing `retokenize()` but this is bad manner for Retokenizer.
All the information for splinted tokens should be passed via attrs argument. 