### PR TITLE
optimize parallel options

### DIFF
--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -243,7 +243,7 @@ def _main_process_write(out_queue: queue, output: _OutputWrapper, parallel_level
     files=("input files", "positional"),
 )
 def run_ginzame(
-    split_mode="C",
+    split_mode=None,
     hash_comment="print",
     output_path=None,
     parallel=-1,

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -51,7 +51,7 @@ class _OutputWrapper:
 def run(
     model_path: Optional[str] = None,
     ensure_model: Optional[str] = None,
-    split_mode: Optional[str] = "C",
+    split_mode: Optional[str] = None,
     hash_comment: str = "print",
     output_path: Optional[Path] = None,
     output_format: str = "0",

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -236,7 +236,6 @@ def _main_process_write(out_queue: queue, output: _OutputWrapper, parallel_level
 
 
 @plac.annotations(
-    model_path=("model directory path", "option", "b", str),
     split_mode=("split mode", "option", "s", str, ["A", "B", "C"]),
     hash_comment=("hash comment", "option", "c", str, ["print", "skip", "analyze"]),
     output_path=("output path", "option", "o", Path),
@@ -244,7 +243,6 @@ def _main_process_write(out_queue: queue, output: _OutputWrapper, parallel_level
     files=("input files", "positional"),
 )
 def run_ginzame(
-    model_path=None,
     split_mode="C",
     hash_comment="print",
     output_path=None,
@@ -252,8 +250,8 @@ def run_ginzame(
     *files,
 ):
     run(
-        model_path=model_path,
-        ensure_model="ja_ginza",
+        model_path=None,
+        ensure_model=None,
         split_mode=split_mode,
         hash_comment=hash_comment,
         output_path=output_path,

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -61,9 +61,25 @@ def run(
     parallel_level: int = 1,
     files: List[str] = None,
 ):
-    if require_gpu:
-        print("GPU enabled", file=sys.stderr)
     assert model_path is None or ensure_model is None
+
+    if parallel_level <= 0:
+        level = max(1, cpu_count() + parallel_level)
+        if output_format in [2, "mecab"]:
+            if require_gpu:
+                print("GPU not used for mecab mode", file=sys.stderr)
+                require_gpu = False
+        elif parallel_level <= 0:
+            if require_gpu:
+                if level < 4:
+                    print("GPU enabled: parallel_level' set to {level}", end="", file=sys.stderr)
+                else:
+                    print("GPU enabled: parallel_level' set to {level} but seems it's too much", end="", file=sys.stderr)
+            else:
+                print(f"'parallel_level' set to {level}", file=sys.stderr)
+        elif require_gpu:
+            print("GPU enabled", file=sys.stderr)
+        parallel_level = level
 
     analyzer = Analyzer(
         model_path,
@@ -75,9 +91,6 @@ def run(
         disable_sentencizer,
         use_normalized_form,
     )
-
-    if parallel_level <= 0:
-        parallel_level = max(1, cpu_count() + parallel_level)
 
     output = _OutputWrapper(output_path, output_format)
     output.open()

--- a/ginza/tests/test_command_line.py
+++ b/ginza/tests/test_command_line.py
@@ -246,7 +246,7 @@ class TestCLIGinza:
 class TestCLIGinzame:
     def test_ginzame(self, input_file):
         p_ginzame = run_cmd(["ginzame", input_file])
-        p_ginza = run_cmd(["ginza", "-n", "-m", "ja_ginza", "-f", "2", input_file])
+        p_ginza = run_cmd(["ginza", "-n", "-m", "ja_ginza", "-f", "2", "-s", "A", input_file])
 
         assert p_ginzame.returncode == 0
         assert p_ginzame.stdout == p_ginza.stdout


### PR DESCRIPTION
- `mecab` mode does not take spaCy model hence `-m` option should be removed from ginzame
- The default split_mode of ginzame is "A"
- Alert if parallel_level became too many