### PR TITLE
assert hash_comment == "analyze" if output format is json

### DIFF
--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -62,7 +62,7 @@ def run(
     files: List[str] = None,
 ):
     assert model_path is None or ensure_model is None
-    assert not (output_format in ["3", "json"] and hash_comment != "analyze"), "output_format=json only accept hash_comment=analyze"
+    assert not (output_format in ["3", "json"] and hash_comment != "analyze")
 
     if parallel_level <= 0:
         level = max(1, cpu_count() + parallel_level)

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -64,8 +64,7 @@ def run(
     assert model_path is None or ensure_model is None
     if output_format in ["3", "json"] and hash_comment != "analyze":
         print(
-            f'hash_comment={hash_comment} may break output json if input contains a line starts with "#".\n'
-            'In order to keep the json in proper format, please use hash_comment=analyze or remove the lines start with "#" from input.',
+            f'hash_comment="{hash_comment}" not permitted for JSON output. Forced to use hash_comment="analyzer".',
             file=sys.stderr
         )
 

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -62,6 +62,7 @@ def run(
     files: List[str] = None,
 ):
     assert model_path is None or ensure_model is None
+    assert not (output_format in ["3", "json"] and hash_comment != "analyze"), "output_format=json only accept hash_comment=analyze"
 
     if parallel_level <= 0:
         level = max(1, cpu_count() + parallel_level)

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -64,7 +64,7 @@ def run(
     assert model_path is None or ensure_model is None
     if output_format in ["3", "json"] and hash_comment != "analyze":
         print(
-            f'hash_comment="{hash_comment}" not permitted for JSON output. Forced to use hash_comment="analyzer".',
+            f'hash_comment="{hash_comment}" not permitted for JSON output. Forced to use hash_comment="analyze".',
             file=sys.stderr
         )
 

--- a/ginza/command_line.py
+++ b/ginza/command_line.py
@@ -62,7 +62,12 @@ def run(
     files: List[str] = None,
 ):
     assert model_path is None or ensure_model is None
-    assert not (output_format in ["3", "json"] and hash_comment != "analyze")
+    if output_format in ["3", "json"] and hash_comment != "analyze":
+        print(
+            f'hash_comment={hash_comment} may break output json if input contains a line starts with "#".\n'
+            'In order to keep the json in proper format, please use hash_comment=analyze or remove the lines start with "#" from input.',
+            file=sys.stderr
+        )
 
     if parallel_level <= 0:
         level = max(1, cpu_count() + parallel_level)

--- a/ginza/tests/test_command_line.py
+++ b/ginza/tests/test_command_line.py
@@ -56,7 +56,7 @@ def output_file(tmpdir: Path) -> Path:
 
 def _conllu_parsable(result: str):
     for line in result.split("\n"):
-        if line.startswith("# text = ") or line.strip() == "":
+        if line.startswith("#") or line.strip() == "":
             continue
         if not len(line.strip().split("\t")) == 10:
             raise Exception
@@ -64,7 +64,7 @@ def _conllu_parsable(result: str):
 
 def _cabocha_parsable(result: str):
     for line in result.split("\n"):
-        if line.strip() in ("", "EOS") or line.startswith("*"):
+        if line.strip() in ("", "EOS") or line.startswith("*") or line.startswith("#"):
             continue
         if not len(line.split("\t")) == 3:
             raise Exception
@@ -74,7 +74,7 @@ def _cabocha_parsable(result: str):
 
 def _mecab_parsable(result: str):
     for line in result.split("\n"):
-        if line.strip() in ("", "EOS"):
+        if line.strip() in ("", "EOS") or line.startswith("#"):
             continue
         if not len(line.split("\t")) == 2:
             raise Exception
@@ -209,6 +209,13 @@ class TestCLIGinza:
         p = run_cmd(["ginza", "-c", "analyze", "-f", output_format, input_file])
         assert p.returncode == 0
         result_parsable(p.stdout.strip())
+
+    @pytest.mark.parametrize(
+        "hash_comment", ["print", "skip"]
+    )
+    def test_json_cannot_accept_hash_comment_not_analyze(self, hash_comment, input_file):
+        p = run_cmd(["ginza", "-c", hash_comment, "-f", "json", input_file])
+        assert p.returncode != 0
 
     def test_require_gpu(self, input_file):
         p = run_cmd(["ginza", "-g", input_file])

--- a/ginza/tests/test_command_line.py
+++ b/ginza/tests/test_command_line.py
@@ -213,9 +213,14 @@ class TestCLIGinza:
     @pytest.mark.parametrize(
         "hash_comment", ["print", "skip"]
     )
-    def test_json_cannot_accept_hash_comment_not_analyze(self, hash_comment, input_file):
-        p = run_cmd(["ginza", "-c", hash_comment, "-f", "json", input_file])
-        assert p.returncode != 0
+    def test_warn_if_json_hash_comment_not_analyze(self, hash_comment, input_file):
+        p = run_cmd(["ginza", "-c", hash_comment, "-f", "json", input_file], stderr=sp.PIPE)
+        assert p.returncode == 0
+        msg = (
+            f'hash_comment={hash_comment} may break output json if input contains a line starts with "#".\n'
+            'In order to keep the json in proper format, please use hash_comment=analyze or remove the lines start with "#" from input.'
+        )
+        assert msg in p.stderr
 
     def test_require_gpu(self, input_file):
         p = run_cmd(["ginza", "-g", input_file])


### PR DESCRIPTION
When "print" or "skip" are specified as "hash_comment" option, it breaks json format and json paraser becomes unable to parse the result.
Added assertion about hash_comment and output_format.