### PR TITLE
add gpu_id argument to --require-gpu option

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Please read the official documents to compile user dictionaries with `sudachipy`
   - All spaCy models, including non-Japanese, are now available with the ginza command #217
     - Download and analyze the model at once by specifying the model name in the following form #219
     - `ginza -m en_core_web_md`
+  - Change `ginza --require_gpu`  and `ginza -g` to take a `gpu_id` argument
+    - The default `gpu_id` value is `-1` which uses only CPUs
   - `ginza -f json` option always analyze the line which starts with `#` regardless the option value of `-c`. #215
 - Improvements
   - Batch analysis processing speeds up by 50-60% in GPU environment and 10-40% in CPU environment

--- a/docs/command_line_tool.md
+++ b/docs/command_line_tool.md
@@ -75,8 +75,8 @@ EOS
         - `2`, `mecab`
         - `3`, `json`
     デフォルト値は `conllu` です。
-- `--require-gpu`, `-g`
-    gpu を有効にするブールスイッチ。gpu_id=0 の gpu が利用されます。
+- `--require-gpu <int>`, `-g <int>`
+    引数で指定されたgpu_idのGPUを使用して解析を行います。引数に-1を指定(デフォルト)するとCPUを使用します。ただし、[spaCyおよびcupyの制約](https://github.com/explosion/spaCy/issues/5507)から、`--require-gpu`は`--parallel`と同時に指定できません。
 - `--use-normalized-form`, `-n`
     `-f conllu`のlemmaフィールドに [sudachi](https://github.com/WorksApplications/Sudachi#normalized-form) を使用するためのブールスイッチ。
 - `--disable-sentencizer`, `-d`

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,13 @@
 - ginzaコマンドで日本語以外を含む全てのspaCyモデルが利用可能に
   - `ginza -m en_core_web_md` の形でモデル名を指定することで[CoNLL-U](https://universaldependencies.org/format.html#syntactic-annotation)出力ツールとして利用可能
 - [ginzaコマンドの解説ページ](https://megagonlabs.github.io/ginza/command_line_tool.html)の記述を拡充
+  - `ginza`コマンドで使用するGPUのgpu_idを`ginza -g 1`の形で指定可能に
 
 ***GiNZAをアップグレードする際は下記の互換性情報を確認してください。***
 
 ## GiNZA v5.1 互換性情報
+- `ginza --require_gpu`および`ginza -g`オプションが引数にgpu_idを取るようになりました
+  - gpu_idに-1を指定(デフォルト)するとCPUのみを使用します
 - v5.0以前の`ja_ginza`および`ja_ginza_electra`パケージはGiNZA v5.1で使用できません（旧バージョン向けパッケージは事前にアンインストールが必要です）
   - `pip uninstall ginza ; pip uninstall ja_ginza ; pip uninstall ja_ginza_electra`
 - transformersモデルの追加に伴いGiNZA v5.1インストール時は`ginza`パッケージとともに解析モデルパッケージを明示的に指定する必要があります
@@ -268,6 +271,8 @@ Contains information from mC4 which is made available under the ODC Attribution 
     - `force_using_normalized_form_as_lemma(True)` -> `token.norm_`
   - ginzaコマンドで日本語以外を含む全てのspaCyモデルが利用可能に #217
     - `ginza -m en_core_web_md` の形でモデル名を指定することでモデルのダウンロードと解析をまとめて実行 #219
+  - `ginza --require_gpu`および`ginza -g`オプションがgpu_idを引数を取る形に変更
+    - -1を指定(デフォルト)するとCPUのみを使用
   - ginza -f json で -c オプションの指定に関わらず#で始まるはもすべて解析対象とする #215
 - Improvements
   - バッチ解析処理をGPU環境で50〜60%・CPU環境で10〜40%高速化

--- a/ginza/analyzer.py
+++ b/ginza/analyzer.py
@@ -2,6 +2,8 @@
 import sys
 from typing import Iterable, Optional
 
+import thinc
+
 import spacy
 from spacy.tokens import Doc, Span
 from spacy.language import Language
@@ -42,7 +44,7 @@ class Analyzer:
         split_mode: str,
         hash_comment: str,
         output_format: str,
-        require_gpu: bool,
+        require_gpu: int,
         disable_sentencizer: bool,
         use_normalized_form: bool,
     ) -> None:
@@ -59,8 +61,8 @@ class Analyzer:
         if self.nlp:
             return
 
-        if self.require_gpu:
-            spacy.require_gpu()
+        if self.require_gpu >= 0:
+            thinc.api.require_gpu(self.require_gpu)
 
         if self.output_format in ["2", "mecab"]:
             nlp = try_sudachi_import(self.split_mode)


### PR DESCRIPTION
Here occurs `cudaErrorInitializationError` when specifying `--require-gpu` along with `--parallel`.
https://github.com/explosion/spaCy/issues/5507
https://github.com/chainer/chainer/issues/1087

I'm going to alert if both above options are specified and going to add `gpu_id` argument to `--require-gpu`.