### PR TITLE
stop using deepcopy in compound spliter test to speed up

### DIFF
--- a/ginza/tests/test_models.py
+++ b/ginza/tests/test_models.py
@@ -176,7 +176,6 @@ def test_tokenize(nlp, text, expected_tokens):
 def test_compound_spliter(nlp, text, len_a, len_b, len_c):
     assert len(nlp(text)) == len_c
     for split_mode, l in zip(["A", "B", "C"], [len_a, len_b, len_c]):
-        nlp = deepcopy(nlp)
         set_split_mode(nlp, split_mode)
         assert len(nlp(text)) == l
 


### PR DESCRIPTION
<summary>
run test for compound_spliter in this branch (5 sec.)
</summary>
<details>

```
(.venv) *[feature/speedup_tests][~/ghq/github.com/r-terada/ginza]$ pytest --durations=0 ginza/tests/test_models.py::test_compound_spliter     
==================================================== test session starts =====================================================
platform darwin -- Python 3.9.9, pytest-7.1.1, pluggy-1.0.0
rootdir: /Users/teradarintarou/ghq/github.com/r-terada/ginza
plugins: mock-3.7.0
collected 8 items                                                                                                            

ginza/tests/test_models.py ........                                                                                    [100%]

====================================================== warnings summary ======================================================
ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza_electra]
ginza/tests/test_models.py::test_compound_spliter[\u5ba2\u5ba4\u4e57\u52d9\u54e1-3-2-1-ja_ginza_electra]
ginza/tests/test_models.py::test_compound_spliter[\u52b4\u50cd\u8005\u5354\u540c\u7d44\u5408-4-3-1-ja_ginza_electra]
ginza/tests/test_models.py::test_compound_spliter[\u6a5f\u80fd\u6027\u98df\u54c1-3-2-1-ja_ginza_electra]
  /Users/teradarintarou/ghq/github.com/r-terada/ginza/.venv/lib/python3.9/site-packages/torch/autocast_mode.py:162: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
    warnings.warn('User provided device_type of \'cuda\', but CUDA is not available. Disabling')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== slowest durations ======================================================
1.51s setup    ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza_electra]
1.22s setup    ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza]
0.24s call     ginza/tests/test_models.py::test_compound_spliter[\u6a5f\u80fd\u6027\u98df\u54c1-3-2-1-ja_ginza_electra]
0.23s call     ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza_electra]
0.23s call     ginza/tests/test_models.py::test_compound_spliter[\u52b4\u50cd\u8005\u5354\u540c\u7d44\u5408-4-3-1-ja_ginza_electra]
0.23s call     ginza/tests/test_models.py::test_compound_spliter[\u5ba2\u5ba4\u4e57\u52d9\u54e1-3-2-1-ja_ginza_electra]
0.06s call     ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza]
0.06s call     ginza/tests/test_models.py::test_compound_spliter[\u6a5f\u80fd\u6027\u98df\u54c1-3-2-1-ja_ginza]
0.06s call     ginza/tests/test_models.py::test_compound_spliter[\u52b4\u50cd\u8005\u5354\u540c\u7d44\u5408-4-3-1-ja_ginza]
0.05s call     ginza/tests/test_models.py::test_compound_spliter[\u5ba2\u5ba4\u4e57\u52d9\u54e1-3-2-1-ja_ginza]

(14 durations < 0.005s hidden.  Use -vv to show these durations.)
=============================================== 8 passed, 4 warnings in 5.12s 
```
</details>


<summary>
run test for compound_spliter in develop branch (66sec.)
</summary>
<details>
================================================
(.venv) *[feature/speedup_tests][~/ghq/github.com/r-terada/ginza]$ gcd                      
Switched to branch 'develop'
Your branch is up to date with 'origin/develop'.
(.venv) *[develop][~/ghq/github.com/r-terada/ginza]$ pytest --durations=0 ginza/tests/test_models.py::test_compound_spliter
==================================================== test session starts =====================================================
platform darwin -- Python 3.9.9, pytest-7.1.1, pluggy-1.0.0
rootdir: /Users/teradarintarou/ghq/github.com/r-terada/ginza
plugins: mock-3.7.0
collected 8 items                                                                                                            

ginza/tests/test_models.py ........                                                                                    [100%]

====================================================== warnings summary ======================================================

ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza_electra]
ginza/tests/test_models.py::test_compound_spliter[\u5ba2\u5ba4\u4e57\u52d9\u54e1-3-2-1-ja_ginza_electra]
ginza/tests/test_models.py::test_compound_spliter[\u52b4\u50cd\u8005\u5354\u540c\u7d44\u5408-4-3-1-ja_ginza_electra]
ginza/tests/test_models.py::test_compound_spliter[\u6a5f\u80fd\u6027\u98df\u54c1-3-2-1-ja_ginza_electra]
  /Users/teradarintarou/ghq/github.com/r-terada/ginza/.venv/lib/python3.9/site-packages/torch/autocast_mode.py:162: UserWarning: User provided device_type of 'cuda', but CUDA is not available. Disabling
    warnings.warn('User provided device_type of \'cuda\', but CUDA is not available. Disabling')

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== slowest durations ======================================================
12.23s call     ginza/tests/test_models.py::test_compound_spliter[\u52b4\u50cd\u8005\u5354\u540c\u7d44\u5408-4-3-1-ja_ginza]
12.03s call     ginza/tests/test_models.py::test_compound_spliter[\u5ba2\u5ba4\u4e57\u52d9\u54e1-3-2-1-ja_ginza]
11.99s call     ginza/tests/test_models.py::test_compound_spliter[\u6a5f\u80fd\u6027\u98df\u54c1-3-2-1-ja_ginza]
11.80s call     ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza]
4.95s call     ginza/tests/test_models.py::test_compound_spliter[\u6a5f\u80fd\u6027\u98df\u54c1-3-2-1-ja_ginza_electra]
3.17s call     ginza/tests/test_models.py::test_compound_spliter[\u5ba2\u5ba4\u4e57\u52d9\u54e1-3-2-1-ja_ginza_electra]
3.15s call     ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza_electra]
3.12s call     ginza/tests/test_models.py::test_compound_spliter[\u52b4\u50cd\u8005\u5354\u540c\u7d44\u5408-4-3-1-ja_ginza_electra]
1.43s setup    ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza_electra]
1.30s setup    ginza/tests/test_models.py::test_compound_spliter[\u9078\u6319\u7ba1\u7406\u59d4\u54e1\u4f1a-4-3-1-ja_ginza]

(14 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================== 8 passed, 4 warnings in 66.44s (0:01:06) ==========================================
</details>