### PR TITLE
add pytest github actions workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,34 @@
+name: pytest
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  pytest:
+    name: Run tests with pytest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: >-
+          python -m
+          pip install -U pip
+      - name: Install dependencies
+        run: >-
+          python -m
+          pip install . pytest pytest-mock ja-ginza ja-ginza-electra
+      - name: Run Tests
+        run: pytest


### PR DESCRIPTION
Added a github actions workflow for running pytest.
As in https://github.com/r-terada/ginza/actions/runs/2028476292, it takes about 5 minutes to run the test, so I believe that it is possible to run the test within the free 2000 minutes/month quota.