### PR TITLE
Fix clause marker rules setter

### DIFF
--- a/ginza/bunsetu_recognizer.py
+++ b/ginza/bunsetu_recognizer.py
@@ -194,7 +194,10 @@ class BunsetuRecognizer:
 
     @clause_marker_rules.setter
     def clause_marker_rules(self, _clause_marker_rules: List[Dict[str, str]]):
-        self._clause_markers = [{k: re.compile(v) for k, v in rules} for rules in _clause_marker_rules]
+        self._clause_marker_rules = [
+            {k: re.compile(v) for k, v in rules.items()}
+            for rules in _clause_marker_rules
+        ]
 
     @property
     def min_bunsetu_num_in_clause(self) -> int:

--- a/ginza/tests/test_bunsetu_recognizer.py
+++ b/ginza/tests/test_bunsetu_recognizer.py
@@ -1,0 +1,10 @@
+from ginza.bunsetu_recognizer import BunsetuRecognizer
+
+
+def test_bunsetu_recognizer_clause_marker_rules_setter():
+    recognizer = BunsetuRecognizer(None)
+    rules = [{"tag_": "補助記号-読点"}, {"pos_": "PUNCT"}]
+
+    recognizer.clause_marker_rules = rules
+
+    assert recognizer.clause_marker_rules == rules


### PR DESCRIPTION
## Summary

- fix `BunsetuRecognizer.clause_marker_rules` setter to update `_clause_marker_rules`
- compile regex patterns from each rule dictionary with `rules.items()`
- add a small regression test for the property round trip

This is related to #211 because it covers one of the pipeline component property setting paths.

## Checks

- `python3 -m py_compile ginza/bunsetu_recognizer.py ginza/tests/test_bunsetu_recognizer.py`
- `git diff --check`

I could not run pytest locally in this Codex environment because `spacy` is not installed.
